### PR TITLE
Add explainer to 'Add Attendance Record' for 'start' time

### DIFF
--- a/src/pages/attendance/view.tsx
+++ b/src/pages/attendance/view.tsx
@@ -1,6 +1,6 @@
 import MemberLayout from "../../components/MemberLayout";
 import Page from "../../components/Page";
-import { addDoc, collection, query, Timestamp, updateDoc, where, deleteDoc, doc, orderBy, getDocs, getDoc } from "firebase/firestore";
+import { addDoc, collection, query, Timestamp, updateDoc, deleteDoc, doc, orderBy, getDocs, getDoc } from "firebase/firestore";
 import { db, docConverter, functions } from "../../config/firebase";
 import { useCollectionData } from "react-firebase-hooks/firestore";
 import React, { forwardRef, useEffect, useMemo, useState } from "react";
@@ -115,6 +115,11 @@ const AddAttendanceRecord = ({ onClose }: { onClose: () => void }) => {
                         rules={{required: true}}
                         />
                 </div>
+                <ul>
+                    <li>* The "start" time refers to the beginning of the activity.</li>
+                    <li>* Students can start scanning their attendance 30 minutes before the "start" time.</li>
+                    <li>* After the "end" time, the attendance record will be closed and no further scans will be accepted.</li>
+                </ul>
             </div>
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
Fixes #17

Add an explainer for the "start" time in the "Add Attendance Record" form.

* Add a bullet list below the "Start Time" field in the `AddAttendanceRecord` component explaining the "start" time.
* Explain that the "start" time refers to the beginning of the activity.
* Mention that students can start scanning their attendance 30 minutes before the "start" time.
* State that after the "end" time, the attendance record will be closed and no further scans will be accepted.
* Remove unused import `where` from the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cecclphs/website-v3/pull/18?shareId=2fe00646-44fe-4bf3-85a8-d68a47e2c515).